### PR TITLE
Adding pipeline: rel_16_0_0_tables_log_delta_table

### DIFF
--- a/workspace/pipeline/rel_16_0_0_tables_log_delta_table.json
+++ b/workspace/pipeline/rel_16_0_0_tables_log_delta_table.json
@@ -1,0 +1,31 @@
+{
+	"name": "rel_16_0_0_tables_log_delta_table",
+	"properties": {
+		"activities": [
+			{
+				"name": "Create tables_log Delta Table",
+				"type": "SynapseNotebook",
+				"dependsOn": [],
+				"policy": {
+					"timeout": "0.12:00:00",
+					"retry": 0,
+					"retryIntervalInSeconds": 30,
+					"secureOutput": false,
+					"secureInput": false
+				},
+				"userProperties": [],
+				"typeProperties": {
+					"notebook": {
+						"referenceName": "py_create_logging_delta_table",
+						"type": "NotebookReference"
+					},
+					"snapshot": true
+				}
+			}
+		],
+		"folder": {
+			"name": "Releases/16.0.0"
+		},
+		"annotations": []
+	}
+}


### PR DESCRIPTION
Adding a release pipeline to run the notebook py_create_logging_delta_table and create table_logs Table in logging DB.
	
 
