### PR TITLE
Feat/theodw 2132 modify generic py utils common logging output notebook

### DIFF
--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -20,12 +20,12 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "a412e252-7741-4c38-a05f-7f3d0cd7ee73"
+				"spark.autotune.trackingId": "34dafcc5-6b97-40f0-86c7-a106bc08ad96"
 			}
 		},
 		"metadata": {
 			"saveOutput": true,
-			"enableDebugMode": true,
+			"enableDebugMode": false,
 			"kernelspec": {
 				"name": "synapse_pyspark",
 				"display_name": "Synapse PySpark"
@@ -63,10 +63,8 @@
 				"source": [
 					"#### The purpose of this pyspark notebook is to read json format files for service bus and appends into single owb_standarsied_db Delta tables.\r\n",
 					"\r\n",
-					"**Author** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **Created Date** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **Description**  \r\n",
-					"Rohit Shukla &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;15-Jul-2025 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The functionality of this notebook is to ingest odw-standardised/ServiceBus Delta Tables after &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;successful reading of json formatted data.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n",
-					"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n",
-					"Rohit Shukla &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;15-Jul-2025 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The addtitional functionality has been added to log the audit information to Application Insight by &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;creating a Json dump at notebook exist&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n",
+					"**Description**  \r\n",
+					"The functionality of this notebook is to ingest odw-standardised/ServiceBus Delta Tables after successful reading of json formatted data.The addtitional functionality has been added to log the audit information to Application Insight by creating a Json dump at notebook exist&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n",
 					"\r\n",
 					"**Spark Cluster Configuration** -> Apache Spark Version- 3.4, Python Version \t\t- 3.10, Delta Lake Version \t- 2.4\r\n",
 					"\r\n",
@@ -182,7 +180,7 @@
 					}
 				},
 				"source": [
-					"##### Initialize Logging Output "
+					"##### Initialize Application Insight Logging functions"
 				]
 			},
 			{
@@ -684,9 +682,11 @@
 					"    app_insight_logger.add_table_result(                    \r\n",
 					"                        delta_table_name = table_name, \r\n",
 					"                        insert_count = insert_count, \r\n",
+					"                        update_count = 0, \r\n",
+					"                        delete_count = 0, \r\n",
 					"                        table_result = \"success\",\r\n",
 					"                        start_exec_time = start_exec_time, \r\n",
-					"                        end_exec_time = start_exec_time,\r\n",
+					"                        end_exec_time = end_exec_time,\r\n",
 					"                        total_exec_time = \"\",\r\n",
 					"                        error_message = \"\"\r\n",
 					"                        )\r\n",
@@ -702,9 +702,11 @@
 					"    app_insight_logger.add_table_result(\r\n",
 					"                        delta_table_name = table_name,\r\n",
 					"                        insert_count = insert_count,\r\n",
+					"                        update_count = 0, \r\n",
+					"                        delete_count = 0, \r\n",
 					"                        table_result = \"failed\",\r\n",
 					"                        start_exec_time = start_exec_time, \r\n",
-					"                        end_exec_time = start_exec_time,\r\n",
+					"                        end_exec_time = end_exec_time,\r\n",
 					"                        total_exec_time = \"\",\r\n",
 					"                        error_message = error_message\r\n",
 					"                        )"
@@ -749,9 +751,11 @@
 					"    app_insight_logger.add_table_result(\r\n",
 					"                        delta_table_name = table_name,\r\n",
 					"                        insert_count = insert_count,\r\n",
+					"                        update_count = 0, \r\n",
+					"                        delete_count = 0, \r\n",
 					"                        table_result = \"failed\",\r\n",
 					"                        start_exec_time = start_exec_time, \r\n",
-					"                        end_exec_time = start_exec_time,\r\n",
+					"                        end_exec_time = end_exec_time,\r\n",
 					"                        total_exec_time = \"\",\r\n",
 					"                        error_message = error_msg\r\n",
 					"                        )\r\n",
@@ -759,6 +763,19 @@
 					"    logInfo(\"Rows appended successfully.\")"
 				],
 				"execution_count": null
+			},
+			{
+				"cell_type": "markdown",
+				"metadata": {
+					"nteract": {
+						"transient": {
+							"deleting": false
+						}
+					}
+				},
+				"source": [
+					"##### Produce Json format output"
+				]
 			},
 			{
 				"cell_type": "code",

--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "34dafcc5-6b97-40f0-86c7-a106bc08ad96"
+				"spark.autotune.trackingId": "3b0c5c1b-853e-4052-9ce0-f517c5349494"
 			}
 		},
 		"metadata": {
@@ -87,7 +87,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "code",
@@ -109,7 +109,7 @@
 					"entity_name='appeal-has'\r\n",
 					"date_folder=''"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "code",
@@ -125,7 +125,7 @@
 					"from pyspark.sql.functions import *\r\n",
 					"import re"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "code",
@@ -150,7 +150,7 @@
 					"spark_schema = StructType.fromJson(json.loads(schema)) if schema != '' else ''\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 4
 			},
 			{
 				"cell_type": "code",
@@ -168,7 +168,7 @@
 				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
-				"execution_count": null
+				"execution_count": 5
 			},
 			{
 				"cell_type": "markdown",
@@ -188,7 +188,7 @@
 				"source": [
 					"%run utils/py_utils_common_logging_output"
 				],
-				"execution_count": null
+				"execution_count": 6
 			},
 			{
 				"cell_type": "code",
@@ -221,7 +221,7 @@
 					"\r\n",
 					"    return max_value"
 				],
-				"execution_count": null
+				"execution_count": 7
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\r\n",
 					"    return formatted_timestamp"
 				],
-				"execution_count": null
+				"execution_count": 8
 			},
 			{
 				"cell_type": "code",
@@ -302,7 +302,7 @@
 					"    \r\n",
 					"    return files"
 				],
-				"execution_count": null
+				"execution_count": 9
 			},
 			{
 				"cell_type": "code",
@@ -342,7 +342,7 @@
 					"\r\n",
 					"    return missing_files"
 				],
-				"execution_count": null
+				"execution_count": 10
 			},
 			{
 				"cell_type": "code",
@@ -384,7 +384,7 @@
 					"\r\n",
 					"    return filtered_paths"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -430,7 +430,7 @@
 					"\r\n",
 					"    return df"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -465,7 +465,7 @@
 					"    return df\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -497,7 +497,7 @@
 					"    .saveAsTable(table_name)\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 14
 			},
 			{
 				"cell_type": "code",
@@ -528,7 +528,7 @@
 					"    \"\"\"\r\n",
 					"    return new_table_row_count == expected_new_count"
 				],
-				"execution_count": null
+				"execution_count": 15
 			},
 			{
 				"cell_type": "markdown",
@@ -593,7 +593,7 @@
 					"        logError(f\"Error getting list of missing files:\\n{e}\")\r\n",
 					"        error_message = app_insight_logger.format_error_message(e, max_length=300)"
 				],
-				"execution_count": null
+				"execution_count": 16
 			},
 			{
 				"cell_type": "markdown",
@@ -642,7 +642,7 @@
 					"    logError(f\"Error deduping and generating counts:\\n{e}\")\r\n",
 					"    error_message = app_insight_logger.format_error_message(e, max_length=300)"
 				],
-				"execution_count": null
+				"execution_count": 17
 			},
 			{
 				"cell_type": "markdown",
@@ -695,7 +695,7 @@
 					"    new_table_row_count = spark.table(table_name).count()\r\n",
 					"except Exception as e:\r\n",
 					"    logError(f\"Error appending rows:\\n{e}\")\r\n",
-					"    error_message = format_error_message(e, max_length=300)\r\n",
+					"    error_message = app_insight_logger.format_error_message(e, max_length=300)\r\n",
 					"    \r\n",
 					"    end_exec_time = str(datetime.now())\r\n",
 					"    \r\n",
@@ -711,7 +711,7 @@
 					"                        error_message = error_message\r\n",
 					"                        )"
 				],
-				"execution_count": null
+				"execution_count": 20
 			},
 			{
 				"cell_type": "markdown",
@@ -762,7 +762,7 @@
 					"else:\r\n",
 					"    logInfo(\"Rows appended successfully.\")"
 				],
-				"execution_count": null
+				"execution_count": 21
 			},
 			{
 				"cell_type": "markdown",
@@ -783,7 +783,7 @@
 					"# Exit with the JSON result\r\n",
 					"mssparkutils.notebook.exit(app_insight_logger.generate_processing_results())"
 				],
-				"execution_count": null
+				"execution_count": 22
 			}
 		]
 	}

--- a/workspace/notebook/py_sb_raw_to_std.json
+++ b/workspace/notebook/py_sb_raw_to_std.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "3b0c5c1b-853e-4052-9ce0-f517c5349494"
+				"spark.autotune.trackingId": "2882d9d5-96ec-4a80-9c73-8d6cc96e3017"
 			}
 		},
 		"metadata": {
@@ -87,7 +87,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -109,7 +109,7 @@
 					"entity_name='appeal-has'\r\n",
 					"date_folder=''"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -125,7 +125,7 @@
 					"from pyspark.sql.functions import *\r\n",
 					"import re"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -150,7 +150,7 @@
 					"spark_schema = StructType.fromJson(json.loads(schema)) if schema != '' else ''\r\n",
 					""
 				],
-				"execution_count": 4
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -168,7 +168,7 @@
 				"source": [
 					"%run service-bus/py_spark_df_ingestion_functions"
 				],
-				"execution_count": 5
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -188,7 +188,7 @@
 				"source": [
 					"%run utils/py_utils_common_logging_output"
 				],
-				"execution_count": 6
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -221,7 +221,7 @@
 					"\r\n",
 					"    return max_value"
 				],
-				"execution_count": 7
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -259,7 +259,7 @@
 					"    formatted_timestamp: str = max_timestamp.strftime(\"%Y-%m-%dT%H:%M:%S.%f\")+\"+0000\"\r\n",
 					"    return formatted_timestamp"
 				],
-				"execution_count": 8
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -302,7 +302,7 @@
 					"    \r\n",
 					"    return files"
 				],
-				"execution_count": 9
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -342,7 +342,7 @@
 					"\r\n",
 					"    return missing_files"
 				],
-				"execution_count": 10
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -384,7 +384,7 @@
 					"\r\n",
 					"    return filtered_paths"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -430,7 +430,7 @@
 					"\r\n",
 					"    return df"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -465,7 +465,7 @@
 					"    return df\r\n",
 					""
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -497,7 +497,7 @@
 					"    .saveAsTable(table_name)\r\n",
 					""
 				],
-				"execution_count": 14
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -528,7 +528,7 @@
 					"    \"\"\"\r\n",
 					"    return new_table_row_count == expected_new_count"
 				],
-				"execution_count": 15
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -593,7 +593,7 @@
 					"        logError(f\"Error getting list of missing files:\\n{e}\")\r\n",
 					"        error_message = app_insight_logger.format_error_message(e, max_length=300)"
 				],
-				"execution_count": 16
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -642,7 +642,7 @@
 					"    logError(f\"Error deduping and generating counts:\\n{e}\")\r\n",
 					"    error_message = app_insight_logger.format_error_message(e, max_length=300)"
 				],
-				"execution_count": 17
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -711,7 +711,7 @@
 					"                        error_message = error_message\r\n",
 					"                        )"
 				],
-				"execution_count": 20
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -762,7 +762,7 @@
 					"else:\r\n",
 					"    logInfo(\"Rows appended successfully.\")"
 				],
-				"execution_count": 21
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -783,7 +783,7 @@
 					"# Exit with the JSON result\r\n",
 					"mssparkutils.notebook.exit(app_insight_logger.generate_processing_results())"
 				],
-				"execution_count": 22
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_utils_common_logging_output.json
+++ b/workspace/notebook/py_utils_common_logging_output.json
@@ -20,12 +20,12 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "f3845a70-6731-4789-89c0-4bf4b27a6cde"
+				"spark.autotune.trackingId": "570c805b-ddaa-4a9f-a097-fd8cdd099e08"
 			}
 		},
 		"metadata": {
 			"saveOutput": true,
-			"enableDebugMode": true,
+			"enableDebugMode": false,
 			"kernelspec": {
 				"name": "synapse_pyspark",
 				"display_name": "Synapse PySpark"
@@ -63,8 +63,8 @@
 				"source": [
 					"#### The purpose of this generic pyspark notebook is to provide all public functions to prodcude the logging output in Json format which can be consumed for Application Insights logging purpose.\r\n",
 					"\r\n",
-					"**Author** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **Created Date** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; **Description**  \r\n",
-					"Rohit Shukla &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;22-Jul-2025 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The functionality of this notebook is generic to cater to produce in the form of public functions which can be reused Application Insights logging purpose.\r\n",
+					"**Description**  \r\n",
+					"The functionality of this notebook is generic to cater to produce in the form of public functions which can be reused Application Insights logging purpose.\r\n",
 					"\r\n",
 					"**Spark Cluster Configuration** -> Apache Spark Version- 3.4, Python Version \t\t- 3.10, Delta Lake Version \t- 2.4\r\n",
 					"\r\n",
@@ -189,6 +189,8 @@
 					"    def add_table_result(self, \r\n",
 					"                        delta_table_name: str = \"\", \r\n",
 					"                        insert_count: int = 0, \r\n",
+					"                        update_count: int = 0, \r\n",
+					"                        delete_count: int = 0, \r\n",
 					"                        table_result: str = \"success\",\r\n",
 					"                        start_exec_time: str = \"\",\r\n",
 					"                        end_exec_time: str = \"\",\r\n",
@@ -216,6 +218,8 @@
 					"        table_detail = {\r\n",
 					"            \"delta_table_name\": delta_table_name,\r\n",
 					"            \"insert_count\": insert_count,\r\n",
+					"            \"update_count\": update_count,\r\n",
+					"            \"delete_count\": delete_count,\r\n",
 					"            \"table_result\": table_result,\r\n",
 					"            \"start_exec_time\": start_exec_time,\r\n",
 					"            \"end_exec_time\": end_exec_time,\r\n",

--- a/workspace/notebook/py_utils_common_logging_output.json
+++ b/workspace/notebook/py_utils_common_logging_output.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "8ccfe24d-3783-45bb-af0f-10afbf62dcaf"
+				"spark.autotune.trackingId": "1bcd7be1-c7de-49ba-8ce1-8ef56724d8cd"
 			}
 		},
 		"metadata": {
@@ -105,7 +105,7 @@
 					"from typing import Dict, Any, Union\r\n",
 					""
 				],
-				"execution_count": 1
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -125,7 +125,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": 2
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -302,7 +302,7 @@
 					"        \r\n",
 					"        return error_message"
 				],
-				"execution_count": 3
+				"execution_count": null
 			},
 			{
 				"cell_type": "markdown",
@@ -322,7 +322,7 @@
 				"source": [
 					"app_insight_logger = ProcessingLogger()"
 				],
-				"execution_count": 4
+				"execution_count": null
 			}
 		]
 	}

--- a/workspace/notebook/py_utils_common_logging_output.json
+++ b/workspace/notebook/py_utils_common_logging_output.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "570c805b-ddaa-4a9f-a097-fd8cdd099e08"
+				"spark.autotune.trackingId": "8ccfe24d-3783-45bb-af0f-10afbf62dcaf"
 			}
 		},
 		"metadata": {
@@ -105,7 +105,7 @@
 					"from typing import Dict, Any, Union\r\n",
 					""
 				],
-				"execution_count": null
+				"execution_count": 1
 			},
 			{
 				"cell_type": "markdown",
@@ -125,7 +125,7 @@
 				"source": [
 					"%run utils/py_logging_decorator"
 				],
-				"execution_count": null
+				"execution_count": 2
 			},
 			{
 				"cell_type": "markdown",
@@ -302,7 +302,7 @@
 					"        \r\n",
 					"        return error_message"
 				],
-				"execution_count": null
+				"execution_count": 3
 			},
 			{
 				"cell_type": "markdown",
@@ -322,7 +322,7 @@
 				"source": [
 					"app_insight_logger = ProcessingLogger()"
 				],
-				"execution_count": null
+				"execution_count": 4
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
