### PR TITLE
Updating notebook: appeal_event_curated_mipins

### DIFF
--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "61e51462-eb20-46e4-8335-b1db557a08e4"
+				"spark.autotune.trackingId": "71473da0-d1ad-4f98-9dd0-0d09c3aef10c"
 			}
 		},
 		"metadata": {
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 32,
-				"automaticScaleJobs": true
+				"memory": 28,
+				"automaticScaleJobs": false
 			},
 			"sessionKeepAliveTimeout": 30
 		},
@@ -96,9 +96,9 @@
 					"    ,RowID\n",
 					"    ,IsActive\n",
 					"FROM\n",
-					"    odw_harmonised_db.sb_appeal_event"
+					"    odw_harmonised_db.appeal_event where  ODTSourceSystem='ODT'"
 				],
-				"execution_count": null
+				"execution_count": 11
 			},
 			{
 				"cell_type": "code",
@@ -116,7 +116,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
 				],
-				"execution_count": null
+				"execution_count": 12
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +163,7 @@
 					"\n",
 					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
-				"execution_count": null
+				"execution_count": 13
 			},
 			{
 				"cell_type": "code",
@@ -181,9 +181,9 @@
 				},
 				"source": [
 					"#%%sql\n",
-					"#select * from odw_curated_db.appeal_event_curated_mipins"
+					"#select * from odw_curated_db.appeal_event_curated_mipins where isactive='N'"
 				],
-				"execution_count": null
+				"execution_count": 14
 			}
 		]
 	}

--- a/workspace/notebook/appeal_event_curated_mipins.json
+++ b/workspace/notebook/appeal_event_curated_mipins.json
@@ -20,7 +20,7 @@
 				"spark.dynamicAllocation.enabled": "false",
 				"spark.dynamicAllocation.minExecutors": "2",
 				"spark.dynamicAllocation.maxExecutors": "2",
-				"spark.autotune.trackingId": "71473da0-d1ad-4f98-9dd0-0d09c3aef10c"
+				"spark.autotune.trackingId": "c5e54b65-4c55-4d5a-b33c-9c579679861c"
 			}
 		},
 		"metadata": {
@@ -98,7 +98,7 @@
 					"FROM\n",
 					"    odw_harmonised_db.appeal_event where  ODTSourceSystem='ODT'"
 				],
-				"execution_count": 11
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -116,7 +116,7 @@
 				"source": [
 					"spark.sql(f\"drop table if exists odw_curated_db.appeal_event_curated_mipins;\")"
 				],
-				"execution_count": 12
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -163,7 +163,7 @@
 					"\n",
 					"df.write.format(\"delta\").mode(\"Overwrite\").saveAsTable(\"odw_curated_db.appeal_event_curated_mipins\")"
 				],
-				"execution_count": 13
+				"execution_count": null
 			},
 			{
 				"cell_type": "code",
@@ -183,7 +183,7 @@
 					"#%%sql\n",
 					"#select * from odw_curated_db.appeal_event_curated_mipins where isactive='N'"
 				],
-				"execution_count": 14
+				"execution_count": null
 			}
 		]
 	}


### PR DESCRIPTION
**PR Template**

 1. Are there new source to raw datasets?
	
	 - [ ] If yes - has a trigger been attached at the appropriate frequency?
  	 - [ ] No

 2. Have any new tables been created in Standardised?

  	- [ ] No
   	- [ ] If yes:
		- [ ] orchestration.json has been updated and tested in Dev and has been / is about to be PRd into main
		- [ ] the new schema exists inside *odw-config/standardised-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
		- [ ] Is the raw-to-standardised python script scheduled to run for this dataset grouping?
 3. Have any new tables been created in Harmonised or Curated?

   	 - [ ] No
     	 - [ ] If yes
	 	- [ ]  *2-odw-standardised-to-harmonised/py_odw_harmonised_table_creation* OR 4-*odw-harmonised-to-curated/py_odw_curated_table_creation* are set up to run in the pipeline *pln_post_deployments* with the base parameter specifying the correct table
		- [ ] the new schema exists inside *odw-config/harmonised-table-definitions* / *odw-config/curated-table-definitions* OR is about to be PRd into main
			- Make sure to run Platform Integrate and Platform Deploy to Dev at least to ensure the schema is deployed into Synapse Dev Live 
 4. Have any tables changed AND/OR have any columns changed in any scripts?
We only care about new columns or columns that change type.
	- [ ] No
 	- [ ] If yes:
		- [ ] Please set py_change_table to run in the pipeline *pln_post_deployments*
		- [ ] Please create a script to backdate and fill in this new column in Test and Prod
			Only delete and recreate tables with caution!
 4. Have any scripts run in isolation in dev? Please look at the *"spark.autotune.trackingId"*
		- If these changes need to be reflected in Test and Prod, please add to the pipeline *post-			deployment/pln_post_deployment*
	- [ ] Yes - I have reflected this script in the *pln_post_deployments* pipeline
	- [ ] Yes - This script is part of a scheduled run and has been added to the appropriate end to end pipeline with a trigger at the correct frequency
	- [ ] No - This change does not need to take place in Test and Prod
	- [ ] No - No scripts have run 
	
 
