### PR TITLE
THEODW-2227: Update notebook configurations for pln_rest_api pipeline

### DIFF
--- a/workspace/notebook/entraid.json
+++ b/workspace/notebook/entraid.json
@@ -46,8 +46,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 32,
+				"automaticScaleJobs": true
 			},
 			"sessionKeepAliveTimeout": 30
 		},

--- a/workspace/notebook/py_horizon_harmonised_aie_document.json
+++ b/workspace/notebook/py_horizon_harmonised_aie_document.json
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 32,
+				"automaticScaleJobs": true
 			},
 			"sessionKeepAliveTimeout": 30
 		},

--- a/workspace/notebook/py_load_listed_buildings_to_harmonised.json
+++ b/workspace/notebook/py_load_listed_buildings_to_harmonised.json
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 32,
+				"automaticScaleJobs": true
 			},
 			"sessionKeepAliveTimeout": 30
 		},

--- a/workspace/notebook/py_load_listed_buildings_to_standardised.json
+++ b/workspace/notebook/py_load_listed_buildings_to_standardised.json
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 32,
+				"automaticScaleJobs": true
 			},
 			"sessionKeepAliveTimeout": 30
 		},

--- a/workspace/notebook/py_raw_to_std.json
+++ b/workspace/notebook/py_raw_to_std.json
@@ -45,8 +45,8 @@
 				"sparkVersion": "3.4",
 				"nodeCount": 3,
 				"cores": 4,
-				"memory": 28,
-				"automaticScaleJobs": false
+				"memory": 32,
+				"automaticScaleJobs": true
 			},
 			"sessionKeepAliveTimeout": 30
 		},


### PR DESCRIPTION
- Updated memory from 28GB to 32GB for all notebooks in pln_rest_api pipeline
- Enabled automaticScaleJobs (from false to true) for better resource scaling
- Updated configurations in notebook metadata.a365ComputeOptions section:
  - py_raw_to_std.json
  - py_horizon_harmonised_aie_document.json
  - entraid.json
  - py_load_listed_buildings_to_standardised.json
  - py_load_listed_buildings_to_harmonised.json
- These changes should help resolve pipeline timeout issues in Listed Buildings and EntraID pipelines

